### PR TITLE
feat(js): support pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 Use another machine to proxy OpenList's traffic.
 
-- [x] Cloudflare Workers
-- [x] Golang
-
-## Usage
+## CLI Usage (Go)
 
 ```shell
 Usage of OpenList-Proxy:
@@ -28,3 +25,32 @@ Usage of OpenList-Proxy:
   -version
         show version and exit
 ```
+
+## Functions Deployment (JavaScript)
+
+### Cloudflare Workers
+
+1. Paste content from [openlist-proxy.js](./openlist-proxy.js) to Cloudflare Workers Dashboard.
+
+2. Setting the following environment in the dashboard:
+
+   - `ADDRESS`: OpenList backend server address (do not include trailing slash)
+
+   - `TOKEN`: API access token (secret key) for OpenList server
+
+   - `WORKER_ADDRESS`: Full address of your Cloudflare Worker (starts with 'http://' or 'https://')
+
+   - `DISABLE_SIGN`: Whether to disable signature verification (recommended to set as false)
+
+### Cloudflare Pages:
+
+1. Upload [openlist-proxy.js](./openlist-proxy.js) under the name `_index.js`.
+
+2. Setting the environment (refer to [Cloudflare Workers](#cloudflare-workers)) in the dashboard.
+
+
+### EdgeOne Pages:
+
+1. Upload `openlist-proxy.js` to the path `/functions/[[default]].js`. Please note that the `functions` directory is required.
+
+2. Setting the environment (refer to [Cloudflare Workers](#cloudflare-workers)) in the dashboard.

--- a/README.md
+++ b/README.md
@@ -30,27 +30,44 @@ Usage of OpenList-Proxy:
 
 ### Cloudflare Workers
 
-1. Paste content from [openlist-proxy.js](./openlist-proxy.js) to Cloudflare Workers Dashboard.
+1. Copy the entire contents of [`openlist-proxy.js`](./openlist-proxy.js).
 
-2. Setting the following environment in the dashboard:
+2. Navigate to the Cloudflare Workers Dashboard.
+
+3. Create a new Worker or edit an existing one.
+
+4. Paste the copied code into the worker editor.
+
+5. Configure the following environment variables:
 
    - `ADDRESS`: OpenList backend server address (do not include trailing slash)
 
    - `TOKEN`: API access token (secret key) for OpenList server
 
-   - `WORKER_ADDRESS`: Full address of your Cloudflare Worker (starts with 'http://' or 'https://')
-
    - `DISABLE_SIGN`: Whether to disable signature verification (recommended to set as false)
+
+6. Save and deploy your worker.
 
 ### Cloudflare Pages:
 
-1. Upload [openlist-proxy.js](./openlist-proxy.js) under the name `_index.js`.
+1. Rename `openlist-proxy.js` to `_index.js`.
 
-2. Setting the environment (refer to [Cloudflare Workers](#cloudflare-workers)) in the dashboard.
+2. Upload the renamed file to your Pages project.
 
+3. In the Cloudflare Pages dashboard, navigate to Settings → Environment variables.
+
+4. Add the same environment variables as described in the [Cloudflare Workers](#cloudflare-workers) section.
+
+5. Deploy your Pages project.
 
 ### EdgeOne Pages:
 
-1. Upload `openlist-proxy.js` to the path `/functions/[[default]].js`. Please note that the `functions` directory is required.
+1. Create a `functions` directory in your project root (if it doesn't exist).
 
-2. Setting the environment (refer to [Cloudflare Workers](#cloudflare-workers)) in the dashboard.
+2. Copy [openlist-proxy.js](./openlist-proxy.js) to the path `/functions/[[default]].js`.
+
+   - **Important:** The file must be named `[[default]].js` and placed inside the `functions` folder.
+
+3. In the EdgeOne Pages dashboard, configure the environment variables as described in the [Cloudflare Workers](#cloudflare-workers) section.
+
+4. Deploy your project.

--- a/openlist-proxy.js
+++ b/openlist-proxy.js
@@ -1,5 +1,5 @@
 // src/const.js
-// Environment variables will be injected by Cloudflare Worker runtime
+// Environment variables will be injected by runtime
 // These will be set during the fetch function execution
 let ADDRESS, TOKEN, WORKER_ADDRESS, DISABLE_SIGN;
 
@@ -11,8 +11,8 @@ function initConstants(env) {
   // OpenList 服务器的 API 访问令牌 (密钥)
   // API access token (secret key) for OpenList server
   TOKEN = env.TOKEN || "YOUR_TOKEN";
-  // Cloudflare Worker 的完整地址
-  // Full address of your Cloudflare Worker
+  // Cloudflare Worker 的完整地址 (以 'http://' 或 'https://' 开头)
+  // Full address of your Cloudflare Worker (starts with 'http://' or 'https://')
   WORKER_ADDRESS = env.WORKER_ADDRESS || "YOUR_WORKER_ADDRESS";
   // 是否禁用签名验证 (推荐设置为 false)
   // Whether to disable signature verification (recommended to set as false)
@@ -212,18 +212,28 @@ async function handleRequest(request) {
 }
 
 // src/index.js
-/**
- * Cloudflare Worker entry point.
- * @param {Request} request - The incoming request.
- * @param {any} env - Environment bindings.
- * @param {ExecutionContext} ctx - Execution context.
- * @returns {Promise<Response>} Response from the handler.
- */
-var src_default = {
+export default {
+  /**
+   * Cloudflare Workers entry point.
+   * @param {Request} request - The incoming request.
+   * @param {any} env - Environment bindings.
+   * @param {ExecutionContext} ctx - Execution context.
+   * @returns {Promise<Response>} Response from the handler.
+   */
   async fetch(request, env, ctx) {
     // Initialize constants from environment variables
     initConstants(env);
     return await handleRequest(request);
   },
 };
-export { src_default as default };
+
+/**
+ * Cloudflare / EdgeOne Pages entry point.
+ * @param {{ request: Request; env: any; }} context - The incoming request context.
+ * @returns {Promise<Response>} Response from the handler.
+ */
+export async function onRequest(context) {
+  const { request, env } = context;
+  initConstants(env);
+  return await handleRequest(request);
+}

--- a/openlist-proxy.js
+++ b/openlist-proxy.js
@@ -1,7 +1,7 @@
 // src/const.js
 // Environment variables will be injected by runtime
 // These will be set during the fetch function execution
-let ADDRESS, TOKEN, WORKER_ADDRESS, DISABLE_SIGN;
+let ADDRESS, TOKEN, DISABLE_SIGN;
 
 // Function to initialize constants from environment variables
 function initConstants(env) {
@@ -11,9 +11,6 @@ function initConstants(env) {
   // OpenList 服务器的 API 访问令牌 (密钥)
   // API access token (secret key) for OpenList server
   TOKEN = env.TOKEN || "YOUR_TOKEN";
-  // Cloudflare Worker 的完整地址 (以 'http://' 或 'https://' 开头)
-  // Full address of your Cloudflare Worker (starts with 'http://' or 'https://')
-  WORKER_ADDRESS = env.WORKER_ADDRESS || "YOUR_WORKER_ADDRESS";
   // 是否禁用签名验证 (推荐设置为 false)
   // Whether to disable signature verification (recommended to set as false)
   // 隐私警告：关闭签名会造成文件可被任何知晓路径的人获取
@@ -133,29 +130,20 @@ async function handleDownload(request) {
   if (res.code !== 200) {
     return new Response(JSON.stringify(res));
   }
-  request = new Request(res.data.url, request);
+  let header = new Headers(request.headers);
   if (res.data.header) {
     for (const k in res.data.header) {
       for (const v of res.data.header[k]) {
-        request.headers.set(k, v);
+        header.set(k, v);
       }
     }
   }
+  request = new Request(res.data.url, {
+    method: "GET",
+    headers: header,
+    redirect: "follow",
+  });
   let response = await fetch(request);
-  while (response.status >= 300 && response.status < 400) {
-    const location = response.headers.get("Location");
-    if (location) {
-      if (location.startsWith(`${WORKER_ADDRESS}/`)) {
-        request = new Request(location, request);
-        return await handleRequest(request);
-      } else {
-        request = new Request(location, request);
-        response = await fetch(request);
-      }
-    } else {
-      break;
-    }
-  }
   response = new Response(response.body, response);
   response.headers.delete("set-cookie");
   response.headers.delete("Alt-Svc");


### PR DESCRIPTION
1. 增加导出 `onRequest` 方法，支持 Pages 部署
2. 自动跟随重定向，移除 `WORKER_ADDRESS` 参数
3. 更改回源请求头部构建方式，修复 EdgeOne Pages 无法改头
4. 增加了部署方法说明

测试了 EO、ESA、CF 的 Pages 反代度盘，没有问题。
